### PR TITLE
use the full array of promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ var processContent = function processContent(data, baseUrl) {
         promises = [].slice.call(inliningStyle);
     }
 
-    promises.concat([].slice.call(inliningScripts));
+    promises = promises.concat([].slice.call(inliningScripts));
 
     //when all promises have resolved, output the processed html document
     Q.all(promises).then(function() {


### PR DESCRIPTION
this is why the script calls were not always all smooshed: we didn't save the concatenated array of promises